### PR TITLE
Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ LIBNAME = inotify.so
 OMIT_FRAME_POINTER = -fomit-frame-pointer
 
 # Seach for lua .pc file
-LUAPKG_CMD = pkg-config --list-all | grep Lua | awk '{print $$1}'
-CFLAGS = `sh -c "pkg-config \`$(LUAPKG_CMD)\` --cflags"` -fPIC -O3 -Wall
+LUAPKG_CMD = $(shell pkg-config --list-all | grep Lua | awk '{print $$1}')
+CFLAGS = -fPIC -O3 -Wall $(shell pkg-config "$(LUAPKG_CMD)" --cflags)
 LFLAGS = -shared $(OMIT_FRAME_POINTER)
-INSTALL_PATH = `sh -c "pkg-config \`$(LUAPKG_CMD)\` --variable=INSTALL_CMOD"`
+INSTALL_PATH = $(shell pkg-config "$(LUAPKG_CMD)" --variable=INSTALL_CMOD)
 
 ## If your system doesn't have pkg-config, comment out the previous
 ## lines and uncomment and change the following ones according to your
@@ -30,8 +30,10 @@ $(LIBNAME): $(OBJNAME)
 	$(CC) -o $(LIBNAME) -shared $(OBJNAME) $(LFLAGS)
 
 install: $(LIBNAME)
-	install -D -s $(LIBNAME) $(DESTDIR)/$(INSTALL_PATH)/$(LIBNAME)
+	install -D -s $(LIBNAME) $(DESTDIR)$(INSTALL_PATH)/$(LIBNAME)
 
 clean:
 	$(RM) $(LIBNAME) $(OBJNAME)
 
+
+.PHONY: all install clean


### PR DESCRIPTION
I get the following output when building:

```
cc -o linotify.o -c linotify.c `sh -c "pkg-config \`pkg-config --list-all | grep Lua | awk '{print $1}'\` --cflags"` -fPIC -O3 -Wall
usage: lua [options] [script [args]].
Available options are:
  -e stat  execute string 'stat'
  -l name  require library 'name'
  -i       enter interactive mode after executing 'script'
  -v       show version information
  --       stop handling options
  -        execute stdin and stop handling options
cc -o inotify.so -shared linotify.o -shared -fomit-frame-pointer
```

Not sure what's happening there but it doesn't seem right.

I changed all the interpolated pkg-config calls to Make `$(shell)` functions, which seems to fix it and as a side-effect, displays the actual pkg-config flags when building:

```
cc -o linotify.o -c linotify.c -fPIC -O3 -Wall -I/usr/include/luajit-2.0
cc -o inotify.so -shared linotify.o -shared -fomit-frame-pointer
```

...but it may not be portable to non-GNU Make though.
