### PR TITLE
Fixed broken install target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ LIBNAME = inotify.so
 OMIT_FRAME_POINTER = -fomit-frame-pointer
 
 # Seach for lua .pc file
-LUAPKG_CMD = $(shell pkg-config --list-all | grep Lua | awk '{print $$1}')
+LUAPKG_CMD = $(shell pkg-config --list-all | grep Lua | awk 'FNR == 1 {print $$1}')
 CFLAGS = -fPIC -O3 -Wall $(shell pkg-config "$(LUAPKG_CMD)" --cflags)
 LFLAGS = -shared $(OMIT_FRAME_POINTER)
 INSTALL_PATH = $(shell pkg-config "$(LUAPKG_CMD)" --variable=INSTALL_CMOD)
@@ -30,7 +30,7 @@ $(LIBNAME): $(OBJNAME)
 	$(CC) -o $(LIBNAME) -shared $(OBJNAME) $(LFLAGS)
 
 install: $(LIBNAME)
-	install -D -s $(LIBNAME) $(DESTDIR)$(INSTALL_PATH)/$(LIBNAME)
+	install -D -s $(LIBNAME) $(INSTALL_PATH)/$(LIBNAME)
 
 clean:
 	$(RM) $(LIBNAME) $(OBJNAME)


### PR DESCRIPTION
`pkg-config --list-all|grep Lua|awk '{print $$1}'`
returns
```
lua5.3
lua
```
on my system. which causes `pkg-config "$(LUAPKG_CMD)" --variable=INSTALL_CMOD` to return
```
/usr/lib/lua/5.3 /usr/lib/lua/5.3
```
This in turn causes install to fail because it is getting an extra argument.

changing the awk command to `awk {FNR == 1 {print $$1}` causes awk to discard all but the first line grep feeds it. This fixes things on my system, and should not affect anyone for whom it was already working.

Also DESTDIR is never defined--it is empty. I suspect it's a relic of an old version of the Makefile. In any case, it confused me and will probably confuse someone else sooner or later, so I removed it.