### PR TITLE
Protect handle_close to prevent closing an already closed fd

### DIFF
--- a/linotify.c
+++ b/linotify.c
@@ -30,6 +30,7 @@
 
 #define MT_NAME "INOTIFY_HANDLE"
 #define READ_BUFFER_SIZE 1024
+#define INVALID_FD (-1)
 
 struct inotify_context {
     char buffer[READ_BUFFER_SIZE];
@@ -186,8 +187,11 @@ handle_events(lua_State *L)
 
 static int handle_close(lua_State *L)
 {
-    int fd = get_inotify_handle(L, 1);
-    close(fd);
+    int *fd = (int *) luaL_checkudata(L, 1, MT_NAME);
+    if( *fd != INVALID_FD ){
+        close(*fd);
+        *fd = INVALID_FD;
+    }
     return 0;
 }
 


### PR DESCRIPTION
Hi,

This PR is to protect handle_close to prevent closing an already closed fd, especially when gc is called afterwards.

Let me details the sequence of events that :
- create a new inotify handle in scope A
- close the handle, handle_close is called, which calls the POSIX close on the fd.
- exit scope A, the handle has no reference pointing to it
- wait / force Lua garbage collection cycle
- the inotify handle needs to be collected, the handle__gc func is called, it calls handle_close which calls the POSIX close on the fd.

Two possible outcomes:
- the fd value has been re-assigned to another file descriptor (socket, io.open etc), then the later close call is done on a fd that now points to something else, so that's bad
- the fd value has not been re-assigned,  then the later close call is done on a "bad" fd so that's bad too.

The fix here is just to use a predefined value to be able to tell if the close needs to be done or not.

Another improvement could be to check for INVALID_FD in get_inotify_handle func, or the callers of  get_inotify_handle, and maybe throw an error.

Regards,

